### PR TITLE
chrony-nts: fix s6 v3 PID1 (init:false) and run chronyd in foreground (-d)

### DIFF
--- a/chrony-nts/config.yaml
+++ b/chrony-nts/config.yaml
@@ -1,7 +1,7 @@
 name: "Chrony NTP Server (with NTS client)"
 slug: "chrony-nts"
 description: "Secure NTP server for your LAN; optionally authenticates upstream time with NTS."
-version: "1.0.0-beta.1"
+version: "1.0.0-beta.2"
 arch:
   - aarch64
   - amd64
@@ -11,6 +11,7 @@ arch:
 startup: application
 boot: auto
 host_network: true
+init: false
 
 options:
   mode: server                         # "server" uses ntp_server; "pool" uses ntp_pool

--- a/chrony-nts/rootfs/etc/services.d/chronyd/run
+++ b/chrony-nts/rootfs/etc/services.d/chronyd/run
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 CONF="/etc/chrony/chrony.conf"
-FLAGS="-q -f ${CONF}"
+FLAGS="-d -f ${CONF}"
 
 # If user disables touching host clock, add -x
 if bashio::config.false 'set_system_clock'; then


### PR DESCRIPTION
- Set init:false per HA+s6 v3 requirement (prevents s6-overlay pid1 error)
- Switch chronyd from one-shot (-q) to foreground (-d) for proper supervision
- Bump version to 1.0.0-beta.2
